### PR TITLE
Rename main.cpp when creating new project

### DIFF
--- a/create
+++ b/create
@@ -4,4 +4,8 @@ cd `dirname $0`
 
 cp -r templateTask $1
 
+mv $1/main.cpp $1/$1.cpp
+
+sed -i 's/main/'"$1"'/g' $1/CMakeLists.txt
+
 echo "add_subdirectory($1)" >> CMakeLists.txt


### PR DESCRIPTION
When uploading a solution, the judge system automatically selects the correct problem from the drop-down list if the filename matches the problem name. The `create` script can support this if we automatically rename `main.cpp` to e.g. `april-fools.cpp` when invoking `./create april-fools`. This saves us at least one second every time we upload a solution ;)